### PR TITLE
Add support for py3.8-3.11 + update parallelizer library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.1](https://github.com/dataiku/dss-plugin-deepl-translation/releases/tag/v1.0.1) - Support release - 2023-04
+
+- ✨ Added support for Python 3.8-3.11
+
 ## [Version 1.0.0](https://github.com/dataiku/dss-plugin-deepl-translation/releases/tag/v1.0.0) - Initial release - 2021-08
 
 - ✨ Integration with the [DeepL Translation API](https://www.deepl.com/en/translator)

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Dataiku
+   Copyright 2021-2023 Dataiku
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,8 +1,13 @@
 {
   "acceptedPythonInterpreters": [
     "PYTHON36",
-    "PYTHON37"
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311"
   ],
+  "corePackagesSet": "AUTO",
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "nlp-deepl-translation",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "meta": {
         "label": "DeepL Translation",
         "category": "Natural Language Processing",

--- a/python-lib/dkulib/parallelizer/parallelizer.py
+++ b/python-lib/dkulib/parallelizer/parallelizer.py
@@ -301,7 +301,7 @@ class DataFrameParallelizer:
             for batch in chunked(df_row_generator, self.batch_size):
                 futures.append(
                     pool.submit(
-                        fn=self._apply_function_with_error_logging,
+                        self._apply_function_with_error_logging,
                         batch=batch,
                         **pool_kwargs,
                     )


### PR DESCRIPTION
[sc-132128]

Note: This PR has an update to the parallelizer library. The PR for this change is here: https://github.com/dataiku/dss-plugin-dkulib/pull/29

