### PR TITLE
Fix DeepL API authentication, switching from form data to Authorization header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ share/python-wheels/
 *.egg
 MANIFEST
 .DS_Store
+.idea
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.2](https://github.com/dataiku/dss-plugin-deepl-translation/releases/tag/v1.0.2) - Support release - 2026-01
+
+- ✨ Fix API authentication after [DeepL's deprecation of query parameter and request body authentication](https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods)
+
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-deepl-translation/releases/tag/v1.0.1) - Support release - 2023-04
 
 - ✨ Added support for Python 3.8-3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Version 1.0.2](https://github.com/dataiku/dss-plugin-deepl-translation/releases/tag/v1.0.2) - Support release - 2026-01
 
-- ✨ Fix API authentication after [DeepL's deprecation of query parameter and request body authentication](https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods)
+- 👾 Fix API authentication after [DeepL's deprecation of query parameter and request body authentication](https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods)
 
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-deepl-translation/releases/tag/v1.0.1) - Support release - 2023-04
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021-2023 Dataiku
+   Copyright 2021-2026 Dataiku
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "nlp-deepl-translation",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "meta": {
         "label": "DeepL Translation",
         "category": "Natural Language Processing",

--- a/python-lib/deepl_translation_api_client.py
+++ b/python-lib/deepl_translation_api_client.py
@@ -72,10 +72,12 @@ class DeepLClient:
         """
         response = requests.post(
             url=self.deepl_url,
+            headers={
+                "Authorization": "DeepL-Auth-Key {}".format(self.api_key),
+            },
             data={
                 "source_lang": source_language,
                 "target_lang": target_language,
-                "auth_key": self.api_key,
                 "text": text,
                 "split_sentences": split_sentences,
                 "preserve_formatting": preserve_formatting,


### PR DESCRIPTION
Fix authentication after https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods